### PR TITLE
Fix compilation on Fedora 35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(abyss)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+set(CMAKE_C_FLAGS "-fPIE")
+
 set(${PROJECT_NAME}_VERSION_MAJOR 0)
 set(${PROJECT_NAME}_VERSION_MINOR 1)
 


### PR DESCRIPTION
When compiling on Fedora 35, there's an error during linking:

`
[trochej@madtower AbyssEngine-1]$ make
[ 27%] Built target libabyss
[ 33%] Linking C executable "Abyss Engine"
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/abyssengine.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/engine/engine.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/scripting/scripting.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/misc/util.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/misc/ini.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/loader/filesystemloader.c.o: relocation R_X86_64_32S against symbol `filesystem_loader_load' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: CMakeFiles/abyssengine.dir/src/loader/loader.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: ../libabyss/liblibabyss.a(log.c.o): relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
collect2: error: ld returned 1 exit status
make[2]: *** [abyssengine/CMakeFiles/abyssengine.dir/build.make:217: abyssengine/Abyss Engine] Error 1
make[1]: *** [CMakeFiles/Makefile2:160: abyssengine/CMakeFiles/abyssengine.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
`

This requires adding a line to CMakeLists.txt

`
set(CMAKE_C_FLAGS "-fPIE")
`

`
$ gcc --version
gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1)
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
`