### PR TITLE
Added compatibility check because magnet breaks things

### DIFF
--- a/abyssengine/CMakeLists.txt
+++ b/abyssengine/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(${PROJECT_NAME} PRIVATE
         src/misc/util.c src/misc/util.h
         src/misc/ini.c src/misc/ini.h
         src/misc/resources.c src/misc/resources.h
+        src/misc/appcompat.c src/misc/appcompat.h
 
         # Dynamic ------------------------------------------------------
         ${SOURCE_EXTRA}

--- a/abyssengine/src/abyssengine.c
+++ b/abyssengine/src/abyssengine.c
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "engine/engine.h"
+#include "misc/appcompat.h"
 #include <libabyss/log.h>
 #include <libabyss/utils.h>
 #include <stdlib.h>
@@ -41,6 +42,11 @@ int main(int argc, char **argv) {
     _getcwd(cwd_path, 4096);
 #else
     getcwd(cwd_path, 4096);
+#endif
+
+// This checks if the app "Magnet" is running as it causes issues with SDL, hopefully this can be removed later
+#ifdef __APPLE__
+    check_app_compat(); // Ahh macOS you pain in the ass
 #endif
 
     char *ini_file_path = calloc(1, 4096);

--- a/abyssengine/src/abyssengine.c
+++ b/abyssengine/src/abyssengine.c
@@ -18,7 +18,9 @@
 
 #include "config.h"
 #include "engine/engine.h"
+#ifdef __APPLE__
 #include "misc/appcompat.h"
+#endif
 #include <libabyss/log.h>
 #include <libabyss/utils.h>
 #include <stdlib.h>

--- a/abyssengine/src/misc/appcompat.c
+++ b/abyssengine/src/misc/appcompat.c
@@ -37,7 +37,7 @@ void check_app_compat() {
 
         /* walk through other tokens */
         while (token != NULL) {
-            if (strcmp(token, "Spotify.app") == 0) {
+            if (strcmp(token, "Magnet.app") == 0) {
                 log_warn("Detected Installation Of Magnet Window Manager, This may cause lag issues with window dragging, It is recommended to disable magnet while using Abyss Engine due to these issues.");
             }
             token = strtok(NULL, s);

--- a/abyssengine/src/misc/appcompat.c
+++ b/abyssengine/src/misc/appcompat.c
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2021 Tim Sarbin
+ * This file is part of AbyssEngine <https://github.com/AbyssEngine>.
+ *
+ * AbyssEngine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AbyssEngine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AbyssEngine.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libabyss/log.h>
+#include <stdio.h>
+#include <string.h>
+#include <libgen.h>
+
+void check_app_compat() {
+    FILE *fp;
+    char line[2048];
+    char *token;
+    /* Open the command for reading. */
+    fp = popen("/usr/bin/locate .app | grep '\\.app$' | grep Steam", "r");
+    if (fp == NULL) {
+        log_warn("Failed To Check For App Incompatibilities :(");
+    }
+    const char s[3] = ", ";
+    /* Read the output a line at a time - output it. */
+    if (fgets(line, sizeof(line), fp) != NULL) {
+        token = basename(strtok(line, s));
+
+        /* walk through other tokens */
+        while (token != NULL) {
+            if (strcmp(token, "Spotify.app") == 0) {
+                log_warn("Detected Installation Of Magnet Window Manager, This may cause lag issues with window dragging, It is recommended to disable magnet while using Abyss Engine due to these issues.");
+            }
+            token = strtok(NULL, s);
+        }
+        /* close */
+        pclose(fp);
+    }
+}

--- a/abyssengine/src/misc/appcompat.h
+++ b/abyssengine/src/misc/appcompat.h
@@ -1,1 +1,4 @@
+#ifndef ABYSS_APP_COMPAT_H
+#define ABYSS_APP_COMPAT_H
 void check_app_compat();
+#endif

--- a/abyssengine/src/misc/appcompat.h
+++ b/abyssengine/src/misc/appcompat.h
@@ -1,0 +1,1 @@
+void check_app_compat();


### PR DESCRIPTION
The window managing app "Magnet" breaks smooth window dragging in SDL apps. This PR adds a check to see if Magnet is installed and if so displays a warning message.