### PR TITLE
Remove libavresample header

### DIFF
--- a/apps/abyssengine/src/abyssengine.cpp
+++ b/apps/abyssengine/src/abyssengine.cpp
@@ -6,7 +6,6 @@
 #include <libavcodec/version.h>
 #include <libavfilter/version.h>
 #include <libavformat/version.h>
-#include <libavresample/version.h>
 #include <libavutil/log.h>
 #include <libavutil/version.h>
 #include <libswresample/version.h>


### PR DESCRIPTION
Hello, libavresample is completely removed from ffmpeg 5.0 

* https://github.com/FFmpeg/FFmpeg/commit/f3f9041302203e458d720028e6f82fb4fb51d8e1
* https://ffmpeg.org/
* https://archlinux.org/todo/libavresample-drop/

It is not checked by AbyssEngine at build time while libswresample is

```
-- /usr/lib64/cmake/sol2
-- Checking for module 'libavcodec'
--   Found libavcodec, version 59.18.100
-- Checking for module 'libavformat'
--   Found libavformat, version 59.16.100
-- Checking for module 'libavdevice'
--   Found libavdevice, version 59.4.100
-- Checking for module 'libavutil'
--   Found libavutil, version 57.17.100
-- Checking for module 'libavfilter'
--   Found libavfilter, version 8.24.100
-- Checking for module 'libswscale'
--   Found libswscale, version 6.4.100
-- Checking for module 'libswresample'
--   Found libswresample, version 4.3.100
-- Found FFMPEG: /usr/lib/libavcodec.so;/usr/lib/libavformat.so;/usr/lib/libavutil.so;/usr/lib/libswscale.so;/usr/lib/libswresample.so  
-- Found Lua: /usr/lib/liblua5.4.so;/usr/lib/libm.so (found suitable exact version "5.4.4")
```

Seems safe to be removed